### PR TITLE
allow discord.sh to be a symlink

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -30,7 +30,7 @@ curl_ok=$?
 
 get_ts() { date -u --iso-8601=seconds; };
 
-thisdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+thisdir="$(cd "$(dirname $(readlink -f "${BASH_SOURCE[0]}"))" && pwd)"
 webhook_file="${thisdir}/.webhook"
 
 help_text="Usage: discord.sh --webhook-url=<url> [OPTIONS]


### PR DESCRIPTION
This modification uses readlink to follow a symlink of discord.sh back to the discord.sh git folder to find the .webhook file instead of expecting it in same folder as the symlink.  Might be anti-feature though.

_Example usage:_
Checked out the project in `/usr/local/discord.sh`
Created a `discord.sh` in your path by creating sym link like so:
`ln -s /usr/local/discord.sh/discord.sh /usr/local/bin/discord.sh`

Right now if you tried to use discord.sh it would try to default to finding the webhook in `/usr/local/bin/.webhook`.  This change would follow the symlink so you'd find the .webhook in the repo check out location of `/usr/local/discord.sh/.webhook`

This might be an anti-feature because you could use the lack of following a symlink to give yourself ability to have different .webhooks ... but that feels like it would just make your PATH dirty so I'm lean towards this PR's result of giving a unified .webhook.